### PR TITLE
4th axis for grbl Mega

### DIFF
--- a/grbl/config.h
+++ b/grbl/config.h
@@ -35,6 +35,7 @@
 // one configuration file by placing their specific defaults and pin map at the bottom of this file.
 // If doing so, simply comment out these two defines and see instructions below.
 #define DEFAULTS_GENERIC
+#define DEFAULTS_ABC_AXIS
 #define CPU_MAP_2560_INITIAL
 
 // Serial baud rate
@@ -105,6 +106,9 @@
 #define HOMING_CYCLE_0 (1<<Z_AXIS)                // REQUIRED: First move Z to clear workspace.
 #define HOMING_CYCLE_1 ((1<<X_AXIS)|(1<<Y_AXIS))  // OPTIONAL: Then move X,Y at the same time.
 // #define HOMING_CYCLE_2                         // OPTIONAL: Uncomment and add axes mask to enable
+// #define HOMING_CYCLE_3                         // OPTIONAL: Uncomment and add axes mask to enable
+// #define HOMING_CYCLE_4                         // OPTIONAL: Uncomment and add axes mask to enable
+// #define HOMING_CYCLE_5                         // OPTIONAL: Uncomment and add axes mask to enable
 
 // NOTE: The following are two examples to setup homing for 2-axis machines.
 // #define HOMING_CYCLE_0 ((1<<X_AXIS)|(1<<Y_AXIS))  // NOT COMPATIBLE WITH COREXY: Homes both X-Y in one cycle. 

--- a/grbl/cpu_map.h
+++ b/grbl/cpu_map.h
@@ -39,7 +39,10 @@
   #define X_STEP_BIT    2 // MEGA2560 Digital Pin 24
   #define Y_STEP_BIT    3 // MEGA2560 Digital Pin 25
   #define Z_STEP_BIT    4 // MEGA2560 Digital Pin 26
-  #define STEP_MASK ((1<<X_STEP_BIT)|(1<<Y_STEP_BIT)|(1<<Z_STEP_BIT)) // All step bits
+  #define A_STEP_BIT    5 // MEGA2560 Digital Pin 27
+  #define B_STEP_BIT    6 // MEGA2560 Digital Pin 28
+  #define C_STEP_BIT    7 // MEGA2560 Digital Pin 29
+  #define STEP_MASK ((1<<X_STEP_BIT)|(1<<Y_STEP_BIT)|(1<<Z_STEP_BIT)|(1<<A_STEP_BIT)|(1<<B_STEP_BIT)|(1<<C_STEP_BIT)) // All step bits
 
   // Define step direction output pins. NOTE: All direction pins must be on the same port.
   #define DIRECTION_DDR     DDRC
@@ -48,7 +51,10 @@
   #define X_DIRECTION_BIT   7 // MEGA2560 Digital Pin 30
   #define Y_DIRECTION_BIT   6 // MEGA2560 Digital Pin 31
   #define Z_DIRECTION_BIT   5 // MEGA2560 Digital Pin 32
-  #define DIRECTION_MASK ((1<<X_DIRECTION_BIT)|(1<<Y_DIRECTION_BIT)|(1<<Z_DIRECTION_BIT)) // All direction bits
+  #define A_DIRECTION_BIT   4 // MEGA2560 Digital Pin 33
+  #define B_DIRECTION_BIT   3 // MEGA2560 Digital Pin 34
+  #define C_DIRECTION_BIT   2 // MEGA2560 Digital Pin 35
+  #define DIRECTION_MASK ((1<<X_DIRECTION_BIT)|(1<<Y_DIRECTION_BIT)|(1<<Z_DIRECTION_BIT)|(1<<A_DIRECTION_BIT)|(1<<B_DIRECTION_BIT)|(1<<C_DIRECTION_BIT)) // All direction bits
 
   // Define stepper driver enable/disable output pin.
   #define STEPPERS_DISABLE_DDR   DDRB
@@ -64,10 +70,13 @@
   #define X_LIMIT_BIT     4 // MEGA2560 Digital Pin 10
   #define Y_LIMIT_BIT     5 // MEGA2560 Digital Pin 11
   #define Z_LIMIT_BIT     6 // MEGA2560 Digital Pin 12
+  #define A_LIMIT_BIT     0 // MEGA2560 Digital Pin 53
+  #define B_LIMIT_BIT     1 // MEGA2560 Digital Pin 52
+  #define C_LIMIT_BIT     2 // MEGA2560 Digital Pin 51
   #define LIMIT_INT       PCIE0  // Pin change interrupt enable pin
   #define LIMIT_INT_vect  PCINT0_vect 
   #define LIMIT_PCMSK     PCMSK0 // Pin change interrupt register
-  #define LIMIT_MASK ((1<<X_LIMIT_BIT)|(1<<Y_LIMIT_BIT)|(1<<Z_LIMIT_BIT)) // All limit bits
+  #define LIMIT_MASK ((1<<X_LIMIT_BIT)|(1<<Y_LIMIT_BIT)|(1<<Z_LIMIT_BIT)|(1<<A_LIMIT_BIT)|(1<<B_LIMIT_BIT)|(1<<C_LIMIT_BIT)) // All limit bits
 
   // Define spindle enable and spindle direction output pins.
   #define SPINDLE_ENABLE_DDR      DDRH

--- a/grbl/defaults.h
+++ b/grbl/defaults.h
@@ -452,4 +452,21 @@
   #define DEFAULT_HOMING_PULLOFF 1.0 // mm
 #endif
 
+#ifdef DEFAULTS_ABC_AXIS
+  #define DEFAULT_A_STEPS_PER_MM 250.0
+  #define DEFAULT_A_MAX_RATE 500.0 // mm/min
+  #define DEFAULT_A_ACCELERATION (10.0*60*60) // 10*60*60 mm/min^2 = 10 mm/sec^2
+  #define DEFAULT_A_MAX_TRAVEL 200.0 // mm
+
+  #define DEFAULT_B_STEPS_PER_MM 250.0
+  #define DEFAULT_B_MAX_RATE 500.0 // mm/min
+  #define DEFAULT_B_ACCELERATION (10.0*60*60) // 10*60*60 mm/min^2 = 10 mm/sec^2
+  #define DEFAULT_B_MAX_TRAVEL 200.0 // mm
+
+  #define DEFAULT_C_STEPS_PER_MM 250.0
+  #define DEFAULT_C_MAX_RATE 500.0 // mm/min
+  #define DEFAULT_C_ACCELERATION (10.0*60*60) // 10*60*60 mm/min^2 = 10 mm/sec^2
+  #define DEFAULT_C_MAX_TRAVEL 200.0 // mm
+#endif
+
 #endif

--- a/grbl/gcode.c
+++ b/grbl/gcode.c
@@ -528,6 +528,7 @@ uint8_t gc_execute_line(char *line)
       else { coord_select = gc_block.modal.coord_select; } // Index P0 as the active coordinate system
       
       // NOTE: Store parameter data in IJK values. By rule, they are not in use with this command.
+      // FIXME: Instead of IJK, we'd better use: float vector[N_AXIS]; // [DG]
       if (!settings_read_coord_data(coord_select,gc_block.values.ijk)) { FAIL(STATUS_SETTING_READ_FAIL); } // [EEPROM read fail]
 
       // Pre-calculate the coordinate data changes.

--- a/grbl/gcode.c
+++ b/grbl/gcode.c
@@ -282,6 +282,16 @@ uint8_t gc_execute_line(char *line)
            legal g-code words and stores their value. Error-checking is performed later since some
            words (I,J,K,L,P,R) have multiple connotations and/or depend on the issued commands. */
         switch(letter){
+#ifdef A_AXIS
+          case 'A': word_bit = WORD_A; gc_block.values.xyz[A_AXIS] = value; axis_words |= (1<<A_AXIS); break;
+#endif
+#ifdef B_AXIS
+          case 'B': word_bit = WORD_B; gc_block.values.xyz[B_AXIS] = value; axis_words |= (1<<B_AXIS); break;
+#endif
+#ifdef C_AXIS
+          case 'C': word_bit = WORD_C; gc_block.values.xyz[C_AXIS] = value; axis_words |= (1<<C_AXIS); break;
+#endif
+
           // case 'A': // Not supported
           // case 'B': // Not supported
           // case 'C': // Not supported
@@ -810,7 +820,7 @@ uint8_t gc_execute_line(char *line)
   } else {
     bit_false(value_words,(bit(WORD_N)|bit(WORD_F)|bit(WORD_S)|bit(WORD_T))); // Remove single-meaning value words.
   }
-  if (axis_command) { bit_false(value_words,(bit(WORD_X)|bit(WORD_Y)|bit(WORD_Z))); } // Remove axis words.
+  if (axis_command) { bit_false(value_words,(bit(WORD_X)|bit(WORD_Y)|bit(WORD_Z)|bit(WORD_A)|bit(WORD_B)|bit(WORD_C))); } // Remove axis words.
   if (value_words) { FAIL(STATUS_GCODE_UNUSED_WORDS); } // [Unused words]
 
   /* -------------------------------------------------------------------------------------

--- a/grbl/gcode.h
+++ b/grbl/gcode.h
@@ -195,7 +195,7 @@ typedef struct {
 
 typedef struct {
   float f;         // Feed
-  float ijk[3];    // I,J,K Axis arc offsets
+  float ijk[N_AXIS];    // I,J,K Axis arc offsets
   uint8_t l;       // G10 or canned cycles parameters
   int32_t n;       // Line number
   float p;         // G10 or dwell parameters

--- a/grbl/gcode.h
+++ b/grbl/gcode.h
@@ -144,6 +144,10 @@
 #define WORD_Y  11
 #define WORD_Z  12
 
+#define WORD_A  13
+#define WORD_B  14
+#define WORD_C  15
+
 // Define g-code parser position updating flags
 #define GC_UPDATE_POS_TARGET   0 // Must be zero
 #define GC_UPDATE_POS_SYSTEM   1
@@ -199,7 +203,7 @@ typedef struct {
   float r;         // Arc radius
   float s;         // Spindle speed
   uint8_t t;       // Tool selection
-  float xyz[3];    // X,Y,Z Translational axes
+  float xyz[N_AXIS];    // X,Y,Z Translational axes
 } gc_values_t;
 
 

--- a/grbl/motion_control.c
+++ b/grbl/motion_control.c
@@ -227,6 +227,15 @@ void mc_homing_cycle(uint8_t cycle_mask)
     #ifdef HOMING_CYCLE_2
       limits_go_home(HOMING_CYCLE_2);  // Homing cycle 2
     #endif
+    #ifdef HOMING_CYCLE_3
+      limits_go_home(HOMING_CYCLE_3);  // Homing cycle 3
+    #endif
+    #ifdef HOMING_CYCLE_4
+      limits_go_home(HOMING_CYCLE_4);  // Homing cycle 4
+    #endif
+    #ifdef HOMING_CYCLE_5
+      limits_go_home(HOMING_CYCLE_5);  // Homing cycle 5
+    #endif
   }
 
   protocol_execute_realtime(); // Check for reset and set system abort.

--- a/grbl/nuts_bolts.h
+++ b/grbl/nuts_bolts.h
@@ -28,13 +28,13 @@
 #define SOME_LARGE_VALUE 1.0E+38
 
 // Axis array index values. Must start with 0 and be continuous.
-#define N_AXIS 6 // Number of axes
+#define N_AXIS 4 // Number of axes
 #define X_AXIS 0 // Axis indexing value.
 #define Y_AXIS 1
 #define Z_AXIS 2
 #define A_AXIS 3
-#define B_AXIS 4
-#define C_AXIS 5
+//#define B_AXIS 4
+//#define C_AXIS 5
 
 // CoreXY motor assignments. DO NOT ALTER.
 // NOTE: If the A and B motor axis bindings are changed, this effects the CoreXY equations.

--- a/grbl/nuts_bolts.h
+++ b/grbl/nuts_bolts.h
@@ -28,11 +28,13 @@
 #define SOME_LARGE_VALUE 1.0E+38
 
 // Axis array index values. Must start with 0 and be continuous.
-#define N_AXIS 3 // Number of axes
+#define N_AXIS 6 // Number of axes
 #define X_AXIS 0 // Axis indexing value.
 #define Y_AXIS 1
 #define Z_AXIS 2
-// #define A_AXIS 3
+#define A_AXIS 3
+#define B_AXIS 4
+#define C_AXIS 5
 
 // CoreXY motor assignments. DO NOT ALTER.
 // NOTE: If the A and B motor axis bindings are changed, this effects the CoreXY equations.

--- a/grbl/report.c
+++ b/grbl/report.c
@@ -520,6 +520,15 @@ void report_realtime_status()
         if (bit_istrue(lim_pin_state,bit(X_AXIS))) { serial_write('X'); }
         if (bit_istrue(lim_pin_state,bit(Y_AXIS))) { serial_write('Y'); }
         if (bit_istrue(lim_pin_state,bit(Z_AXIS))) { serial_write('Z'); }
+#ifdef A_AXIS
+        if (bit_istrue(lim_pin_state,bit(A_AXIS))) { serial_write('A'); }
+#endif
+#ifdef B_AXIS
+        if (bit_istrue(lim_pin_state,bit(B_AXIS))) { serial_write('B'); }
+#endif
+#ifdef C_AXIS
+        if (bit_istrue(lim_pin_state,bit(C_AXIS))) { serial_write('C'); }
+#endif
       }
       if (ctrl_pin_state) {
         #ifdef ENABLE_SAFETY_DOOR_INPUT_PIN

--- a/grbl/settings.c
+++ b/grbl/settings.c
@@ -107,6 +107,25 @@ void settings_restore(uint8_t restore_flag) {
     settings.max_travel[Y_AXIS] = (-DEFAULT_Y_MAX_TRAVEL);
     settings.max_travel[Z_AXIS] = (-DEFAULT_Z_MAX_TRAVEL);
 
+#ifdef A_AXIS
+    settings.steps_per_mm[A_AXIS] = DEFAULT_A_STEPS_PER_MM;
+    settings.max_rate[A_AXIS] = DEFAULT_A_MAX_RATE;
+    settings.acceleration[A_AXIS] = DEFAULT_A_ACCELERATION;
+    settings.max_travel[A_AXIS] = (-DEFAULT_A_MAX_TRAVEL);
+#endif
+#ifdef B_AXIS
+    settings.steps_per_mm[B_AXIS] = DEFAULT_B_STEPS_PER_MM;
+    settings.max_rate[B_AXIS] = DEFAULT_B_MAX_RATE;
+    settings.acceleration[B_AXIS] = DEFAULT_B_ACCELERATION;
+    settings.max_travel[B_AXIS] = (-DEFAULT_B_MAX_TRAVEL);
+#endif
+#ifdef C_AXIS
+    settings.steps_per_mm[C_AXIS] = DEFAULT_C_STEPS_PER_MM;
+    settings.acceleration[C_AXIS] = DEFAULT_C_ACCELERATION;
+    settings.max_rate[C_AXIS] = DEFAULT_C_MAX_RATE;
+    settings.max_travel[C_AXIS] = (-DEFAULT_C_MAX_TRAVEL);
+#endif
+
     write_global_settings();
   }
 
@@ -317,7 +336,20 @@ uint8_t get_step_pin_mask(uint8_t axis_idx)
 {
   if ( axis_idx == X_AXIS ) { return((1<<X_STEP_BIT)); }
   if ( axis_idx == Y_AXIS ) { return((1<<Y_STEP_BIT)); }
+#if defined(A_AXIS) || defined(B_AXIS) || defined(C_AXIS)
+  if ( axis_idx == Z_AXIS ) { return((1<<Z_STEP_BIT)); }
+#endif
+#ifdef A_AXIS
+  if ( axis_idx == A_AXIS ) { return((1<<A_STEP_BIT)); }
+#endif
+#ifdef B_AXIS
+  if ( axis_idx == B_AXIS ) { return((1<<B_STEP_BIT)); }
+#endif
+#ifdef C_AXIS
+  return((1<<C_STEP_BIT));
+#else
   return((1<<Z_STEP_BIT));
+#endif
 }
 
 
@@ -326,7 +358,20 @@ uint8_t get_direction_pin_mask(uint8_t axis_idx)
 {
   if ( axis_idx == X_AXIS ) { return((1<<X_DIRECTION_BIT)); }
   if ( axis_idx == Y_AXIS ) { return((1<<Y_DIRECTION_BIT)); }
+#if defined(A_AXIS) || defined(B_AXIS) || defined(C_AXIS)
+  if ( axis_idx == Z_AXIS ) { return((1<<Z_DIRECTION_BIT)); }
+#endif
+#ifdef A_AXIS
+  if ( axis_idx == A_AXIS ) { return((1<<A_DIRECTION_BIT)); }
+#endif
+#ifdef B_AXIS
+  if ( axis_idx == B_AXIS ) { return((1<<B_DIRECTION_BIT)); }
+#endif
+#ifdef C_AXIS
+  return((1<<C_DIRECTION_BIT));
+#else
   return((1<<Z_DIRECTION_BIT));
+#endif
 }
 
 
@@ -335,5 +380,18 @@ uint8_t get_limit_pin_mask(uint8_t axis_idx)
 {
   if ( axis_idx == X_AXIS ) { return((1<<X_LIMIT_BIT)); }
   if ( axis_idx == Y_AXIS ) { return((1<<Y_LIMIT_BIT)); }
-  return((1<<Z_LIMIT_BIT));
+#if defined(A_AXIS) || defined(B_AXIS) || defined(C_AXIS)
+  if ( axis_idx == Z_AXIS ) { return((1<<Z_LIMIT_BIT)); }
+#endif
+#ifdef A_AXIS
+  if ( axis_idx == A_AXIS ) { return((1<<A_LIMIT_BIT)); }
+#endif
+#ifdef B_AXIS
+  if ( axis_idx == B_AXIS ) { return((1<<B_LIMIT_BIT)); }
+#endif
+#ifdef C_AXIS
+  return((1<<C_LIMIT_BIT));
+#else
+   return((1<<Z_LIMIT_BIT));
+#endif
 }

--- a/grbl/stepper.c
+++ b/grbl/stepper.c
@@ -350,6 +350,9 @@ ISR(TIMER1_COMPA_vect)
 
         // Initialize Bresenham line and distance counters
         st.counter_x = st.counter_y = st.counter_z = (st.exec_block->step_event_count >> 1);
+#ifdef A_AXIS
+        st.counter_a = st.counter_x;
+#endif
       }
       st.dir_outbits = st.exec_block->direction_bits ^ dir_port_invert_mask;
 

--- a/grbl/system.c
+++ b/grbl/system.c
@@ -324,18 +324,21 @@ uint8_t system_check_travel_limits(float *target)
 {
   uint8_t idx;
   for (idx=0; idx<N_AXIS; idx++) {
-    #ifdef HOMING_FORCE_SET_ORIGIN
-      // When homing forced set origin is enabled, soft limits checks need to account for directionality.
-      // NOTE: max_travel is stored as negative
-      if (bit_istrue(settings.homing_dir_mask,bit(idx))) {
-        if (target[idx] < 0 || target[idx] > -settings.max_travel[idx]) { return(true); }
-      } else {
+    // allow disabling soft limit per axis by setting max travel to zero
+    if (settings.max_travel[idx]) {
+      #ifdef HOMING_FORCE_SET_ORIGIN
+        // When homing forced set origin is enabled, soft limits checks need to account for directionality.
+        // NOTE: max_travel is stored as negative
+        if (bit_istrue(settings.homing_dir_mask,bit(idx))) {
+          if (target[idx] < 0 || target[idx] > -settings.max_travel[idx]) { return(true); }
+        } else {
+          if (target[idx] > 0 || target[idx] < settings.max_travel[idx]) { return(true); }
+        }
+      #else
+        // NOTE: max_travel is stored as negative
         if (target[idx] > 0 || target[idx] < settings.max_travel[idx]) { return(true); }
-      }
-    #else
-      // NOTE: max_travel is stored as negative
-      if (target[idx] > 0 || target[idx] < settings.max_travel[idx]) { return(true); }
     #endif
+  }
   }
   return(false);
 }


### PR DESCRIPTION
Hello,

I'm currently in the process of building a 4th axis for my OX CNC, and I needed to have a cheap controller for it.
I've being using grbl for about a year now, so that seemed the easiest way.
I quickly tested grbl-Mega, it worked for 3 axis, then I found an [old grbl port](https://github.com/electrokean/grbl/commits/6-AXIS) for 6 axis, and I adapted it on grbl-Mega.
On the sender part, I also adapted bCNC to handle the A axis (control & DRO by now). You can check my [repo](https://github.com/dguerizec/bCNC-4axis), I guess it's the easiest way to test this pull request.

I have one question though, in the [last commit](https://github.com/gnea/grbl-Mega/commit/68adb2a411aadb5a72670ddb09f2fbd9ac69c5ae) I've extended the ijk array to match the size of xyz, because it's used as a temporary storage for XYZ (and A...) but that seems wrong to me.
Wouldn't it be better to use a stack allocated array for this temp storage, or is there any reason we want to save stack space ?