### PR TITLE
Report spindle and coolant state independently

### DIFF
--- a/grbl/config.h
+++ b/grbl/config.h
@@ -276,6 +276,7 @@
 #define REPORT_FIELD_WORK_COORD_OFFSET // Default enabled. Comment to disable.
 #define REPORT_FIELD_OVERRIDES // Default enabled. Comment to disable.
 #define REPORT_FIELD_LINE_NUMBERS // Default enabled. Comment to disable.
+#define REPORT_ACCESSORY_STATE // Default enabled. Comment to disable.
 
 // Some status report data isn't necessary for realtime, only intermittently, because the values don't
 // change often. The following macros configures how many times a status report needs to be called before

--- a/grbl/report.c
+++ b/grbl/report.c
@@ -582,19 +582,21 @@ void report_realtime_status()
       print_uint8_base10(sys.r_override);
       serial_write(',');
       print_uint8_base10(sys.spindle_speed_ovr);
-
-      uint8_t sp_state = spindle_get_state();
-      uint8_t cl_state = coolant_get_state();
-      if (sp_state || cl_state) {
-        printPgmString(PSTR("|A:"));
-        if (sp_state) { // != SPINDLE_STATE_DISABLE
-          if (sp_state == SPINDLE_STATE_CW) { serial_write('S'); } // CW
-          else { serial_write('C'); } // CCW
-        }
-        if (cl_state & COOLANT_STATE_FLOOD) { serial_write('F'); }
-        if (cl_state & COOLANT_STATE_MIST) { serial_write('M'); }
-      }  
     }
+  #endif
+
+  #ifdef REPORT_ACCESSORY_STATE
+    uint8_t sp_state = spindle_get_state();
+    uint8_t cl_state = coolant_get_state();
+    if (sp_state || cl_state) {
+      printPgmString(PSTR("|A:"));
+      if (sp_state) { // != SPINDLE_STATE_DISABLE
+        if (sp_state == SPINDLE_STATE_CW) { serial_write('S'); } // CW
+        else { serial_write('C'); } // CCW
+      }
+      if (cl_state & COOLANT_STATE_FLOOD) { serial_write('F'); }
+      if (cl_state & COOLANT_STATE_MIST) { serial_write('M'); }
+    }  
   #endif
 
   serial_write('>');


### PR DESCRIPTION
Since spindle and coolant state (A:...) are reported delayed together with overrides it's not possible to distinguish the state on/off or not reported.
Maybe you want to add this small change.