### PR TITLE
Changed avrdude flash command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@
 
 DEVICE     ?= atmega2560
 CLOCK      = 16000000L
-PROGRAMMER ?= -c avrisp2 -P usb
+PROGRAMMER ?= -c wiring -P /dev/ttyUSB0 -D
 SOURCE    = main.c motion_control.c gcode.c spindle_control.c coolant_control.c serial.c \
              protocol.c stepper.c eeprom.c settings.c planner.c nuts_bolts.c limits.c \
              print.c probe.c report.c system.c sleep.c jog.c


### PR DESCRIPTION
I do not know, if this is a general problem or only with my board:
The original flash routine for avrdude provided within the Makefile did not work for my board. The one from my commit works.