### PR TITLE
Fixes gremlin where changing step and direction inversion masks made a mess

### DIFF
--- a/grbl/stepper.c
+++ b/grbl/stepper.c
@@ -596,7 +596,10 @@ void st_generate_step_dir_invert_masks()
   #ifdef DEFAULTS_RAMPS_BOARD
     for (idx=0; idx<N_AXIS; idx++) {
       if (bit_istrue(settings.step_invert_mask,bit(idx))) { step_port_invert_mask[idx] = get_step_pin_mask(idx); }
+      else { step_port_invert_mask[idx] = 0; }
+
       if (bit_istrue(settings.dir_invert_mask,bit(idx))) { dir_port_invert_mask[idx] = get_direction_pin_mask(idx); }
+      else { dir_port_invert_mask[idx] = 0; }
     }
   #else
     step_port_invert_mask = 0;


### PR DESCRIPTION
This PR fixes a gremlin where changing the stepper step and direction inversion masks didn't work correctly because step_port_invert_mask[] and dir_port_invert_mask[] (new with the RAMPS modifications) weren't reset to 0 when they should have been (when unset).  

This made initial setup more difficult due to likely desynchronization between settings.step_invert_mask and step_port_invert_mask[] and between settings.dir_invert_mask and dir_port_invert_mask[] with a change to $2 or $3, where grbl would ultimately behave as though there was always an inversion.

(Also, while I might have used a ternary to fix this, the way I did it seemed most consistent with grbl style.  Please advise if you'd rather a ternary - easy fix.)