### PR TITLE
Made grbl serial port selectable in config.h

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,12 @@
 *.d
 
 README.md
+.vs/grbl-Mega-serial/v14/.atsuo
+*.eep
+*.lss
+*.map
+*.srec
+*.mk
+Debug/Makefile
+grbl-Mega-serial.componentinfo.xml
+grbl-Mega-serial.cproj

--- a/grbl/config.h
+++ b/grbl/config.h
@@ -29,6 +29,14 @@
 #define config_h
 #include "grbl.h" // For Arduino IDE compatibility.
 
+// If you have a USB to serial (HC04) or Wifi (ESP8266) to serial adapter connected, you have to disconnect this adapter before flashing GRBL.
+// To avoid this, connect the adapter to serial port 1,2 or 3 and tell grbl to use this serial port.
+// You can than flash using the USB port connected to USART0 and communicate to grbl by an other serial port.
+//  Define the serial port to use, the mega2560 has four (USART0 .. USART3) usart0 is the default. Uncomment just one
+#define SERIAL0		//uncomment to use USART0 TX0/RX0 (default)
+//#define SERIAL1		//uncomment to use USART1 TX1/RX1
+//#define SERIAL2		//uncomment to use USART2 TX2/RX2
+//#define SERIAL3		//uncomment to use USART3 TX3/RX3
 
 // Define CPU pin map and default settings.
 // NOTE: OEMs can avoid the need to maintain/update the defaults.h and cpu_map.h files and use only

--- a/grbl/cpu_map.h
+++ b/grbl/cpu_map.h
@@ -28,9 +28,7 @@
 
 #ifdef CPU_MAP_2560_INITIAL // (Arduino Mega 2560) Working @EliteEng
 
-  // Serial port interrupt vectors
-  #define SERIAL_RX USART0_RX_vect
-  #define SERIAL_UDRE USART0_UDRE_vect
+  // Serial port configuration is moved to config.h
 
   // Define step pulse output pins. NOTE: All step bit pins must be on the same port.
   #define STEP_DDR      DDRA

--- a/grbl/serial.c
+++ b/grbl/serial.c
@@ -67,16 +67,16 @@ void serial_init()
   // Set baud rate
   #if BAUD_RATE < 57600
     uint16_t UBRR0_value = ((F_CPU / (8L * BAUD_RATE)) - 1)/2 ;
-    UCSR0A &= ~(1 << U2X0); // baud doubler off  - Only needed on Uno XXX
+    UCSRXA &= ~(1 << U2XX); // baud doubler off  - Only needed on Uno XXX
   #else
     uint16_t UBRR0_value = ((F_CPU / (4L * BAUD_RATE)) - 1)/2;
-    UCSR0A |= (1 << U2X0);  // baud doubler on for high baud rates, i.e. 115200
+    UCSRXA |= (1 << U2XX);  // baud doubler on for high baud rates, i.e. 115200
   #endif
-  UBRR0H = UBRR0_value >> 8;
-  UBRR0L = UBRR0_value;
+  UBRRXH = UBRR0_value >> 8;
+  UBRRXL = UBRR0_value;
 
   // enable rx, tx, and interrupt on complete reception of a byte
-  UCSR0B |= (1<<RXEN0 | 1<<TXEN0 | 1<<RXCIE0);
+  UCSRXB |= (1<<RXENX | 1<<TXENX | 1<<RXCIEX);
 
   // defaults to 8-bit, no parity, 1 stop bit
 }
@@ -99,7 +99,7 @@ void serial_write(uint8_t data) {
   serial_tx_buffer_head = next_head;
 
   // Enable Data Register Empty Interrupt to make sure tx-streaming is running
-  UCSR0B |=  (1 << UDRIE0);
+  UCSRXB |=  (1 << UDRIEX);
 }
 
 
@@ -109,7 +109,7 @@ ISR(SERIAL_UDRE)
   uint8_t tail = serial_tx_buffer_tail; // Temporary serial_tx_buffer_tail (to optimize for volatile)
 
   // Send a byte from the buffer
-  UDR0 = serial_tx_buffer[tail];
+  UDRX = serial_tx_buffer[tail];
 
   // Update tail position
   tail++;
@@ -118,7 +118,7 @@ ISR(SERIAL_UDRE)
   serial_tx_buffer_tail = tail;
 
   // Turn off Data Register Empty Interrupt to stop tx-streaming if this concludes the transfer
-  if (tail == serial_tx_buffer_head) { UCSR0B &= ~(1 << UDRIE0); }
+  if (tail == serial_tx_buffer_head) { UCSRXB &= ~(1 << UDRIEX); }
 }
 
 
@@ -142,7 +142,7 @@ uint8_t serial_read()
 
 ISR(SERIAL_RX)
 {
-  uint8_t data = UDR0;
+  uint8_t data = UDRX;
   uint8_t next_head;
 
   // Pick off realtime command characters directly from the serial stream. These characters are

--- a/grbl/serial.h
+++ b/grbl/serial.h
@@ -33,6 +33,72 @@
 #define SERIAL_NO_DATA 0xff
 
 
+#if defined SERIAL1
+// Serial port interrupt vectors
+  #define SERIAL_RX USART1_RX_vect
+  #define SERIAL_UDRE USART1_UDRE_vect
+  //Serial port register definition
+  #define  UCSRXA UCSR1A
+  #define  UBRRXH UBRR1H
+  #define  UBRRXL UBRR1L
+  #define  UCSRXB UCSR1B
+  #define  UDRIEX UDRIE1
+  #define  UDRX UDR1
+  #define  U2XX U2X1
+  #define  RXCIEX RXCIE1
+  #define  TXENX TXEN1
+  #define  RXENX RXEN1
+#elif defined SERIAL2
+  // Serial port interrupt vectors
+  #define SERIAL_RX USART2_RX_vect
+  #define SERIAL_UDRE USART2_UDRE_vect
+  //Serial port register definition
+  #define  UCSRXA UCSR2A
+  #define  UBRRXH UBRR2H
+  #define  UBRRXL UBRR2L
+  #define  UCSRXB UCSR2B
+  #define  UDRIEX UDRIE2
+  #define  UDRX UDR2
+  #define  U2XX U2X2
+  #define  RXCIEX RXCIE2
+  #define  TXENX TXEN2
+  #define  RXENX RXEN2
+#elif defined SERIAL3
+  // Serial port interrupt vectors
+  #define SERIAL_RX USART3_RX_vect
+  #define SERIAL_UDRE USART3_UDRE_vect
+  //Serial port register definition
+  #define  UCSRXA UCSR3A
+  #define  UBRRXH UBRR3H
+  #define  UBRRXL UBRR3L
+  #define  UCSRXB UCSR3B
+  #define  UDRIEX UDRIE3
+  #define  UDRX UDR3
+  #define  U2XX U2X3
+  #define  RXCIEX RXCIE3
+  #define  TXENX TXEN3
+  #define  RXENX RXEN3
+#else
+  //Atleast one serial port should be defined
+  #ifndef SERIAL0	
+     #warning No serial port defined, using SERIAL0
+  #endif
+  // Serial port interrupt vectors
+  #define SERIAL_RX USART0_RX_vect
+  #define SERIAL_UDRE USART0_UDRE_vect
+  //Serial port register definition
+  #define  UCSRXA UCSR0A
+  #define  UBRRXH UBRR0H
+  #define  UBRRXL UBRR0L
+  #define  UCSRXB UCSR0B
+  #define  UDRIEX UDRIE0
+  #define  UDRX UDR0
+  #define  U2XX U2X0
+  #define  RXCIEX RXCIE0
+  #define  TXENX TXEN0
+  #define  RXENX RXEN0
+#endif
+
 void serial_init();
 
 // Writes one byte to the TX serial buffer. Called by main program.


### PR DESCRIPTION
If you have a USB to serial (HC04) or Wifi (ESP8266) to serial adapter connected to your serial port, you have to disconnect this adapter before flashing GRBL. To avoid this, connect the adapter to USART 1,2 or 3 and change the serial port in config.h. You can than flash using the USB port connected to USART0 and communicate to grbl by an other serial port.
