### PR TITLE
Improve checksum per https://github.com/gnea/grbl-Mega/issues/158

### DIFF
--- a/grbl/eeprom.c
+++ b/grbl/eeprom.c
@@ -130,7 +130,7 @@ void eeprom_put_char( unsigned int addr, unsigned char new_value )
 void memcpy_to_eeprom_with_checksum(unsigned int destination, char *source, unsigned int size) {
   unsigned char checksum = 0;
   for(; size > 0; size--) { 
-    checksum = (checksum << 1) || (checksum >> 7);
+    checksum = (checksum << 1) | (checksum >> 7);
     checksum += *source;
     eeprom_put_char(destination++, *(source++)); 
   }
@@ -141,7 +141,7 @@ int memcpy_from_eeprom_with_checksum(char *destination, unsigned int source, uns
   unsigned char data, checksum = 0;
   for(; size > 0; size--) { 
     data = eeprom_get_char(source++);
-    checksum = (checksum << 1) || (checksum >> 7);
+    checksum = (checksum << 1) | (checksum >> 7);
     checksum += data;    
     *(destination++) = data; 
   }


### PR DESCRIPTION
 Per https://github.com/gnea/grbl-Mega/issues/158  The logical OR squashes the previous checksum down to 1 bit of information, resulting in the final checksum being either the last character written, or one plus the last character written.

This change switches to the bitwise-or to convert the squashing into a 1-bit roll to the left.